### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 A collection of Model Context Protocol (MCP) tools that run on Modal.
 This let's you extend the capabilities of your LLM in tools such as [Goose](https://block.github.io/goose/) or the [Claude Desktop App](https://claude.ai/download).
 
+<a href="https://glama.ai/mcp/servers/ai78w0p5mc"><img width="380" height="200" src="https://glama.ai/mcp/servers/ai78w0p5mc/badge" alt="Modal Toolbox MCP server" /></a>
+
 ## Tools
 
 - `run_python_code_in_sandbox`: Let's you run python code in a sandboxed environment.


### PR DESCRIPTION
This PR adds a badge for the [Modal MCP Toolbox](https://glama.ai/mcp/servers/ai78w0p5mc) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/ai78w0p5mc"><img width="380" height="200" src="https://glama.ai/mcp/servers/ai78w0p5mc/badge" alt="Modal Toolbox MCP server" /></a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.